### PR TITLE
lockdown role and playbook

### DIFF
--- a/redhatnordicssa.vm_panic_mode/.travis.yml
+++ b/redhatnordicssa.vm_panic_mode/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/redhatnordicssa.vm_panic_mode/README.md
+++ b/redhatnordicssa.vm_panic_mode/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/redhatnordicssa.vm_panic_mode/defaults/main.yml
+++ b/redhatnordicssa.vm_panic_mode/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for redhatnordicssa.vm_panic_mode
+local_check_user: awx

--- a/redhatnordicssa.vm_panic_mode/handlers/main.yml
+++ b/redhatnordicssa.vm_panic_mode/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for redhatnordicssa.vm_panic_mode

--- a/redhatnordicssa.vm_panic_mode/meta/main.yml
+++ b/redhatnordicssa.vm_panic_mode/meta/main.yml
@@ -1,0 +1,38 @@
+galaxy_info:
+  author: redhatnordicssa
+  description: Initializes panic mode on a VM using firewalld. This cuts off all incoming and outgoing traffic from a VM.
+  company: Red Hat Nordics
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: GPL-3.0-only
+
+  min_ansible_version: 2.9
+
+  platforms:
+   - name: Fedora
+     versions:
+     - 35
+   - name: EL
+     versions:
+     - 9
+     - 8
+
+  galaxy_tags: 
+    - security
+    - redhat
+    - firewalld
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/redhatnordicssa.vm_panic_mode/tasks/main.yml
+++ b/redhatnordicssa.vm_panic_mode/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# tasks file for redhatnordicssa.vm_panic_mode
+- name: Ensure firewalld is installed
+  ansible.builtin.yum:
+    name: firewalld 
+    state: present
+- name: Ensure firewalld is running and enabled across reboot
+  ansible.builtin.service:
+    name: firewalld
+    state: started
+    enabled: yes
+- name: Active firewalld panic mode
+  command: firewall-cmd --panic-on
+  async: 60
+  poll: 0
+
+- name: Check so that communications now are down
+  wait_for:
+    port: 22
+    timeout: 3
+    search_regex: OpenSSH
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_user: "{{ local_check_user }}"
+  ignore_errors: yes

--- a/redhatnordicssa.vm_panic_mode/tests/inventory
+++ b/redhatnordicssa.vm_panic_mode/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/redhatnordicssa.vm_panic_mode/tests/test.yml
+++ b/redhatnordicssa.vm_panic_mode/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - redhatnordicssa.vm_panic_mode

--- a/vm_panic.yml
+++ b/vm_panic.yml
@@ -1,0 +1,9 @@
+- name: Put VM into panic mode
+  hosts: all
+  gather_facts: no
+  vars:
+    local_check_user: mglantz
+  tasks:
+    - name: Include vm_panic_mode
+      include_role:
+        name: redhatnordicssa.vm_panic_mode


### PR DESCRIPTION
Testing:

```
[mglantz@darkred security]$ ansible-playbook -i ./test ./vm_panic.yml -u root

PLAY [Put VM into panic mode] ****************************************************************************************************************************************************************************************************************

TASK [Include vm_panic_mode] *****************************************************************************************************************************************************************************************************************

TASK [redhatnordicssa.vm_panic_mode : Ensure firewalld is installed] *************************************************************************************************************************************************************************
[DEPRECATION WARNING]: Distribution rhel 9.0 on host rhel9c.sudo.net should use /usr/libexec/platform-python, but is using /usr/bin/python for backward compatibility with prior Ansible releases. A future Ansible release will default to 
using the discovered platform python for this host. See https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for more information. This feature will be removed in version 2.12. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [rhel9c.sudo.net]

TASK [redhatnordicssa.vm_panic_mode : Ensure firewalld is running and enabled across reboot] *************************************************************************************************************************************************
ok: [rhel9c.sudo.net]

TASK [redhatnordicssa.vm_panic_mode : Active firewalld panic mode] ***************************************************************************************************************************************************************************
changed: [rhel9c.sudo.net]

TASK [redhatnordicssa.vm_panic_mode : Check so that communications now are down] *************************************************************************************************************************************************************
fatal: [rhel9c.sudo.net]: FAILED! => {"changed": false, "elapsed": 3, "msg": "Timeout when waiting for search string OpenSSH in 127.0.0.1:22"}
...ignoring

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
rhel9c.sudo.net            : ok=4    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1  
```
